### PR TITLE
Feature/craw 43 support broken links in exporter

### DIFF
--- a/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/model/BrokenLink.java
+++ b/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/model/BrokenLink.java
@@ -3,7 +3,7 @@ package at.ac.fhcampuswien.craw.lib.model;
 public class BrokenLink extends Weblink {
 
 
-    private final States linkStatus;
+    private States linkStatus;
 
     /**
      * Represents the different error states of a link
@@ -50,5 +50,9 @@ public class BrokenLink extends Weblink {
 
     public States getLinkStatus() {
         return linkStatus;
+    }
+
+    public void setLinkStatus(States linkStatus) {
+        this.linkStatus = linkStatus;
     }
 }

--- a/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
+++ b/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
@@ -25,12 +25,6 @@ public class Exporter {
     private List<Weblink> links;    //field + getter and setter are needed by the snakeyaml library to generate YAMLs
 
     public void setLinks(List<Weblink> links) {
-        for (Weblink link :
-                links) {
-            if (link.getClass().equals(BrokenLink.class)) {
-                ((BrokenLink) link).setLinkStatus(((BrokenLink) link).getLinkStatus());
-            }
-        }
         this.links = links;
     }
 

--- a/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
+++ b/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
@@ -1,6 +1,7 @@
 package at.ac.fhcampuswien.craw.lib.services;
 
 import at.ac.fhcampuswien.craw.lib.exceptions.CrawException;
+import at.ac.fhcampuswien.craw.lib.model.BrokenLink;
 import at.ac.fhcampuswien.craw.lib.model.Weblink;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -23,6 +24,12 @@ public class Exporter {
     private List<Weblink> links;    //field + getter and setter are needed by the snakeyaml library to generate YAMLs
 
     public void setLinks(List<Weblink> links) {
+        for (Weblink link :
+                links) {
+            if (link.getClass().equals(BrokenLink.class)){
+                ((BrokenLink) link).setLinkStatus(((BrokenLink) link).getLinkStatus());
+            }
+        }
         this.links = links;
     }
 
@@ -56,6 +63,7 @@ public class Exporter {
     private Yaml getFormattedYAML() {
         Representer representer = new Representer();
         representer.addClassTag(Exporter.class, Tag.MAP);
+        representer.addClassTag(BrokenLink.class, Tag.MAP);
         representer.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         return new Yaml(representer);
     }

--- a/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
+++ b/craw-lib/src/main/java/at/ac/fhcampuswien/craw/lib/services/Exporter.java
@@ -3,6 +3,7 @@ package at.ac.fhcampuswien.craw.lib.services;
 import at.ac.fhcampuswien.craw.lib.exceptions.CrawException;
 import at.ac.fhcampuswien.craw.lib.model.BrokenLink;
 import at.ac.fhcampuswien.craw.lib.model.Weblink;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.yaml.snakeyaml.DumperOptions;
@@ -26,7 +27,7 @@ public class Exporter {
     public void setLinks(List<Weblink> links) {
         for (Weblink link :
                 links) {
-            if (link.getClass().equals(BrokenLink.class)){
+            if (link.getClass().equals(BrokenLink.class)) {
                 ((BrokenLink) link).setLinkStatus(((BrokenLink) link).getLinkStatus());
             }
         }
@@ -81,7 +82,6 @@ public class Exporter {
             file = new File(filePath + ".yml");
         }
 
-
         try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(file))) {
             JSONArray linksAsJSON = convertLinksToJSONFormat(links);
             bufferedWriter.write(linksAsJSON.toJSONString());
@@ -96,8 +96,19 @@ public class Exporter {
             JSONObject linksAsJSON = new JSONObject();
             linksAsJSON.put("url", link.getUrl());
             linksAsJSON.put("name", link.getName());
+            putLinkStatus(link, linksAsJSON);
             JSONArray.add(linksAsJSON);
         }
         return JSONArray;
+    }
+
+    private void putLinkStatus(Weblink link, JSONObject linksAsJSON) {
+        if (link.getClass().equals(BrokenLink.class)) {
+            switch (((BrokenLink) link).getLinkStatus()) {
+                case MALFORMED -> linksAsJSON.put("linkStatus", "MALFORMED");
+                case NOT_OK -> linksAsJSON.put("linkStatus", "NOT_OK");
+                case CONNECTION_ERROR -> linksAsJSON.put("linkStatus", "CONNECTION_ERROR");
+            }
+        }
     }
 }

--- a/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
+++ b/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
@@ -5,6 +5,7 @@ import at.ac.fhcampuswien.craw.lib.model.BrokenLink;
 import at.ac.fhcampuswien.craw.lib.model.Weblink;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -163,16 +164,16 @@ public class ExporterTest {
     class ExporterWithBrokenLinksTest {
 
         private final Exporter exporter = new Exporter();
-        private static List<Weblink> links;
+        private List<Weblink> links;
         private File exportedFile;
         private String fileContent;
 
         @TempDir
         File tempDir;
 
-        @BeforeAll
-        static void createLinksMock() {
-            links = new ArrayList<>();
+        @BeforeEach
+        public void createLinksMock() {
+            this.links = new ArrayList<>();
             links.add(new Weblink("www.google.at", "google"));
             links.add(new BrokenLink("www.orf.at", "orf", NOT_OK));
             links.add(new Weblink("www.github.at", "github"));
@@ -194,7 +195,7 @@ public class ExporterTest {
                     "- name: github  url: www.github.at";
 
             //act
-            this.exporter.writeYAML(YAML, links);
+            this.exporter.writeYAML(YAML, this.links);
             try {
                 exportedFile = getFileFromDirectory(tempDir, "links.yml");
                 fileContent = getFileContent(exportedFile);
@@ -229,7 +230,7 @@ public class ExporterTest {
                     "]";
 
             //act
-            exporter.writeJSON(JSON, links);
+            exporter.writeJSON(JSON, this.links);
             try {
                 exportedFile = getFileFromDirectory(tempDir, "links.json");
                 fileContent = getFileContent(exportedFile);

--- a/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
+++ b/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
@@ -99,6 +99,7 @@ public class ExporterTest {
         //assert
         assertTrue(tempDir.isDirectory(), "Should be a directory");
         assertTrue(exportedFile.exists(), "YAML should exist");
+        assertTrue(fileContent.contains("linkStatus"), "Should contain linkStatus");
         assertEquals("links.yml", exportedFile.getName(), "Should be named links.yml");
         assertEquals(expectedYAML, fileContent, "Content should equal mocked content");
     }
@@ -191,6 +192,7 @@ public class ExporterTest {
         //assert
         assertTrue(tempDir.isDirectory(), "Should be a directory");
         assertTrue(exportedFile.exists(), "JSON should exist");
+        assertTrue(fileContent.contains("linkStatus"), "Should contain linkStatus");
         assertEquals("links.json", exportedFile.getName(), "Should be named links.json");
         assertEquals(expectedJSON, fileContent, "Content should equal mocked content");
     }

--- a/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
+++ b/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
@@ -7,13 +7,17 @@ import at.ac.fhcampuswien.craw.lib.model.Weblink;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static at.ac.fhcampuswien.craw.lib.model.BrokenLink.States.CONNECTION_ERROR;
 import static at.ac.fhcampuswien.craw.lib.model.BrokenLink.States.MALFORMED;
+import static at.ac.fhcampuswien.craw.lib.model.BrokenLink.States.NOT_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,7 +41,7 @@ public class ExporterTest {
 
         linksWithMalformedLink = new ArrayList<>();
         linksWithMalformedLink.add(new Weblink("www.google.at", "google"));
-        linksWithMalformedLink.add(new BrokenLink("www.orf.at", "orf", MALFORMED));
+        linksWithMalformedLink.add(new BrokenLink("www.orf.at", "orf", NOT_OK));
         linksWithMalformedLink.add(new Weblink("www.github.at", "github"));
     }
 
@@ -76,13 +80,23 @@ public class ExporterTest {
      * @throws CrawException thrown if file could not be written to directory, exported file could not be found, or
      *                       if file content could not be read
      */
-    @Test
-    void writeYAMLWithBrokenLinkToCustomDirectory() throws CrawException {
+    @ParameterizedTest
+    @ValueSource(strings = {"MALFORMED", "NOT_OK", "CONNECTION_ERROR"})
+    void writeYAMLWithBrokenLinkToCustomDirectory(String arg) throws CrawException {
         //arrange
         File YAML = new File(tempDir, "links.yml");
+        for (Weblink link : linksWithMalformedLink) {
+            if (link.getClass().equals(BrokenLink.class)) {
+                switch (arg) {
+                    case "MALFORMED" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", MALFORMED));
+                    case "NOT_OK" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", NOT_OK));
+                    case "CONNECTION_ERROR" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", CONNECTION_ERROR));
+                }
+            }
+        }
         final String expectedYAML = "links:" +
                 "- name: google  url: www.google.at" +
-                "- linkStatus: MALFORMED  name: orf  url: www.orf.at" +
+                "- linkStatus: " + arg + "  name: orf  url: www.orf.at" +
                 "- name: github  url: www.github.at";
 
         //act
@@ -168,13 +182,23 @@ public class ExporterTest {
      * @throws CrawException thrown if file could not be written to directory, exported file could not be found, or
      *                       if file content could not be read
      */
-    @Test
-    void writeJSONContainingBrokenLinkToCustomDirectory() throws CrawException {
+    @ParameterizedTest
+    @ValueSource(strings = {"MALFORMED", "NOT_OK", "CONNECTION_ERROR"})
+    void writeJSONContainingBrokenLinkToCustomDirectory(String arg) throws CrawException {
         //arrange
         File JSON = new File(tempDir, "links.json");
+        for (Weblink link : linksWithMalformedLink) {
+            if (link.getClass().equals(BrokenLink.class)) {
+                switch (arg) {
+                    case "MALFORMED" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", MALFORMED));
+                    case "NOT_OK" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", NOT_OK));
+                    case "CONNECTION_ERROR" -> linksWithMalformedLink.set(linksWithMalformedLink.indexOf(link), new BrokenLink("www.orf.at", "orf", CONNECTION_ERROR));
+                }
+            }
+        }
         final String expectedJSON = "[" +
                 "{\"name\":\"google\",\"url\":\"www.google.at\"}," +
-                "{\"linkStatus\":\"MALFORMED\",\"name\":\"orf\",\"url\":\"www.orf.at\"}," +
+                "{\"linkStatus\":\"" + arg + "\",\"name\":\"orf\",\"url\":\"www.orf.at\"}," +
                 "{\"name\":\"github\",\"url\":\"www.github.at\"}" +
                 "]";
 

--- a/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
+++ b/craw-lib/src/test/java/at/ac/fhcampuswien/craw/lib/services/ExporterTest.java
@@ -168,6 +168,38 @@ public class ExporterTest {
      *                       if file content could not be read
      */
     @Test
+    void writeJSONContainingBrokenLinkToCustomDirectory() throws CrawException {
+        //arrange
+        File JSON = new File(tempDir, "links.json");
+        final String expectedJSON = "[" +
+                "{\"name\":\"google\",\"url\":\"www.google.at\"}," +
+                "{\"linkStatus\":\"MALFORMED\",\"name\":\"orf\",\"url\":\"www.orf.at\"}," +
+                "{\"name\":\"github\",\"url\":\"www.github.at\"}" +
+                "]";
+
+        //act
+        exporter.writeJSON(JSON, linksWithMalformedLink);
+        try {
+            exportedFile = getFileFromDirectory(tempDir, "links.json");
+            fileContent = getFileContent(exportedFile);
+        } catch (FileNotFoundException fnfe) {
+            throw new CrawException("Exported JSON could not be found in directory", fnfe);
+        } catch (IOException ioe) {
+            throw new CrawException("JSON content could not be read", ioe);
+        }
+
+        //assert
+        assertTrue(tempDir.isDirectory(), "Should be a directory");
+        assertTrue(exportedFile.exists(), "JSON should exist");
+        assertEquals("links.json", exportedFile.getName(), "Should be named links.json");
+        assertEquals(expectedJSON, fileContent, "Content should equal mocked content");
+    }
+
+    /**
+     * @throws CrawException thrown if file could not be written to directory, exported file could not be found, or
+     *                       if file content could not be read
+     */
+    @Test
     void writeEmptyJSONToCustomDirectory() throws CrawException {
         //arrange
         File JSON = new File(tempDir, "links.json");


### PR DESCRIPTION
## NOTE: 

### The Linkstatus...
* field only exists in a link of an exported file, if the link is of class equals `BrokenLink`. Otherwise it gets exported as a regular link.
* of a broken link is the first field of an exported file (order: `linkstatus`, `name`, `url` )
* is exported as its `ENUM`, **not** as its `value` (this was easier to implement with the YAML Library I used)